### PR TITLE
Forbid applying to past training sessions 

### DIFF
--- a/Android/app/src/main/java/hr/foi/air/fitfusion/TrainingDetails.kt
+++ b/Android/app/src/main/java/hr/foi/air/fitfusion/TrainingDetails.kt
@@ -12,6 +12,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import hr.foi.air.fitfusion.data_classes.FirebaseManager
 import hr.foi.air.fitfusion.data_classes.LoggedInUser
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class TrainingDetails : AppCompatActivity() {
     private lateinit var textViewDisplayId: TextView
@@ -59,8 +61,11 @@ class TrainingDetails : AppCompatActivity() {
             val intent = Intent(this, WeekViewActivity::class.java)
             startActivity(intent)
         }
+        val current = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val dateToString = LocalDate.parse(date, formatter)
 
-        if (loggedUsertype == "trainer" || participants == "0") {
+        if (loggedUsertype == "trainer" || participants == "0" || dateToString.isBefore(current)) {
             applyButton.visibility = View.GONE
         }
         firebaseManager.checkIfUserIsAlreadyApplied(this, id) { hasApplied ->
@@ -68,7 +73,7 @@ class TrainingDetails : AppCompatActivity() {
                 Toast.makeText(this, "You have already applied for this training!", Toast.LENGTH_SHORT).show()
                 applyButton.visibility = View.GONE
             } else {
-                if (loggedUsertype == "user" && participants != "0") {
+                if (loggedUsertype == "user" && participants != "0" && (dateToString.equals(current) || dateToString.isAfter(current))) {
                     applyButton.setOnClickListener {
                         firebaseManager.applyForTraining(this, id)
                         val intent = Intent(this, WeekViewActivity::class.java)

--- a/Android/app/src/main/java/hr/foi/air/fitfusion/data_classes/FirebaseManager.kt
+++ b/Android/app/src/main/java/hr/foi/air/fitfusion/data_classes/FirebaseManager.kt
@@ -594,10 +594,14 @@ class FirebaseManager {
         })
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     fun getTrainings(context: Context, trainingsRecycleView: RecyclerView) {
         val trainingsList = ArrayList<TrainingModel>()
         val loggedInUser = LoggedInUser(context)
         val userId = loggedInUser.getUserId()
+        val current = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+
 
         val dataQuery = database.getReference("Training")
         dataQuery.addListenerForSingleValueEvent(object : ValueEventListener {
@@ -605,7 +609,8 @@ class FirebaseManager {
                 trainingsList.clear()
                 for (trainingSnapshot in snapshot.children) {
                     val training = trainingSnapshot.getValue(TrainingModel::class.java)
-                    if (training != null && userId in training.participantsId.orEmpty()) {
+                    val dateToString = LocalDate.parse(training!!.date, formatter)
+                    if (training != null && userId in training.participantsId.orEmpty() && dateToString.isAfter(current)) {
                         trainingsList.add(training)
                     }
                 }


### PR DESCRIPTION
In TrainingDetails.kt one check was added to se if current date is before or after selected training date and visibility of apply button was handled accordingly. The same check was also added in FirebaseManager.kt under get trainings.
FIT-90